### PR TITLE
Fix issue #9 Connection failure on startup

### DIFF
--- a/nodes/src/index.js
+++ b/nodes/src/index.js
@@ -50,6 +50,9 @@ $( document ).ready(function() {
         transports: ['polling', 'websocket']
     })
 
+    // Make sure we connect the first time ok, wait 2 secs first time then 3, 4.5, etc
+    checkConnect(2000, 1.5)
+
     $('#msgsReceived').text(msgCounter.data)
     $('#msgsControl').text(msgCounter.control)
     $('#msgsSent').text(msgCounter.sent)
@@ -188,6 +191,20 @@ $( document ).ready(function() {
 });
 
 // ----- UTILITY FUNCTIONS ----- //
+
+// try to reconnect after specified delay (msec) and then wait delay * factor and try again, and again...
+var checkConnect = function(delay, factor) {
+    if (timerid) window.clearTimeout(timerid) // we only want one running at a time
+    timerid = window.setTimeout(function(){
+        debug && console.log('Manual SIO reconnect attempt, timeout: ' + delay)
+        // don't need to check whether we have connected as the timer will have been cleared if we have
+        socket.close()    // this is necessary sometimes when the socket fails to connect on startup
+        socket.connect()  // Try to reconnect
+        timerid = null
+        checkConnect(delay*factor, factor) // extend timer for next time round
+    }, delay)
+} // --- End of checkConnect Fn--- //
+
 // send a msg back to Node-RED, NR will generally expect the msg to contain a payload topic
 var sendMsg = function(msgToSend) {
     // Track how many messages have been sent

--- a/nodes/uibuilder.js
+++ b/nodes/uibuilder.js
@@ -361,6 +361,9 @@ module.exports = function(RED) {
             })
 
             socket.on('error', function(err) {
+                log.debug(
+                    `UIbuilder: ${node.url} ERROR received, Reason: ${err.message}, ID: ${socket.id}, Cookie: ${socket.handshake.headers.cookie}`
+                )
                 RED.log.audit({
                     'UIbuilder': node.url+' ERROR received', 'ID': socket.id,
                     'Reason': err.message


### PR DESCRIPTION
Sometimes, particularly on Android for some reason, but also on other systems occasionally, the websocket fails to connect on startup. The solution seems to be to wait a bit after initialising the socket and if it has not connected then call close() and connect() which then connects normally.

Julian, could you do a careful code review of this please, I haven't done anything quite like this in js before. I have tested it as far as practical though. Is there a concern about stack overflow using timers and recursive calling like this in the event it never connects? I am hoping not as the initial call to the function returns immediately and I assume the code run when the timer runs down is executed from elsewhere.

I think the checkConnection function I have added could also be used for the manual reconnect on re-deploy. I don't think the existing code works as intended. Shall I add that in to this PR?

I have also sneaked in a log message in socket.on('error') that I think was probably just forgotten.