### PR TITLE
Add websocket connected state to default page

### DIFF
--- a/nodes/src/index.html
+++ b/nodes/src/index.html
@@ -58,6 +58,7 @@
             node for details on how to use UIbuilder.
         </p>
         <h2>Dynamic Data (via JQuery)</h2>
+        <p>Websocket State: <span id="socketConnectedState"></span></p>
         <p>Messages Received: <span id="msgsReceived"></span></p>
         <p>Control Messages Received: <span id="msgsControl"></span></p>
         <p>Messages Sent: <span id="msgsSent"></span></p>

--- a/nodes/src/index.js
+++ b/nodes/src/index.js
@@ -50,6 +50,7 @@ $( document ).ready(function() {
         transports: ['polling', 'websocket']
     })
 
+    $('#socketConnectedState').text("Disconnected")
     $('#msgsReceived').text(msgCounter.data)
     $('#msgsControl').text(msgCounter.control)
     $('#msgsSent').text(msgCounter.sent)
@@ -58,6 +59,7 @@ $( document ).ready(function() {
     // When the socket is connected .................
     socket.on('connect', function() {
         debug && console.log('SOCKET CONNECTED - Namespace: ' + ioNamespace)
+        $('#socketConnectedState').text("Connected")
 
         // Reset any reconnect timers
         if (timerid) {
@@ -140,6 +142,7 @@ $( document ).ready(function() {
         // reason === 'io server disconnect' - redeploy of Node instance
         // reason === 'transport close' - Node-RED terminating
         debug && console.log('SOCKET DISCONNECTED - Namespace: ' + ioNamespace + ', Reason: ' + reason)
+        $('#socketConnectedState').text("Disconnected")
 
         // A workaround for SIO's failure to reconnect after a NR redeploy of the node instance
         if ( reason === 'io server disconnect' ) {


### PR DESCRIPTION
This might be considered a useful addition to the default page. Users may well wish to indicate the state in some way on their dashboard and this shows where to hook in.