### PR TITLE
Added length checking to lines 105 and 165

### DIFF
--- a/nodes/src/uibuilderfe.js
+++ b/nodes/src/uibuilderfe.js
@@ -102,7 +102,9 @@ if (typeof require !== 'undefined'  &&  typeof io === 'undefined') {
                 var u = window.location.pathname.split('/').filter(function(t) { return t.trim() !== '' })
 
                 // @since 2017-11-06 If the last element of the path is an .html file name, remove it
-                if (u[u.length - 1].endsWith('.html')) u.pop()
+                if (u.length > 0) {  // Issue #73 - Check length of `u`, otherwise endsWith errors with undefined
+                    if (u[u.length - 1].endsWith('.html')) u.pop()
+                }
 
                 // Socket.IO namespace HAS to start with a leading slash
                 ioNamespace = u.join('/')
@@ -160,7 +162,9 @@ if (typeof require !== 'undefined'  &&  typeof io === 'undefined') {
             // split current url path, eliminate any blank elements and trailing or double slashes
             var fullPath = window.location.pathname.split('/').filter(function(t) { return t.trim() !== '' })
             // handle url includes file name
-            if (fullPath[fullPath.length - 1].endsWith('.html')) fullPath.pop()
+            if (fullPath.length > 0) {  // Issue #73 - Check length of `fullPath`, otherwise endsWith errors with undefined
+                if (fullPath[fullPath.length - 1].endsWith('.html')) fullPath.pop()
+            }
             self.url = fullPath.pop() // not actually used and only gives the last path section of the url anyway
             self.httpNodeRoot = '/' + fullPath.join('/')
             self.ioPath       = urlJoin(self.httpNodeRoot, self.moduleName, 'vendor', 'socket.io')


### PR DESCRIPTION
### A reference to any related issues in this repository
Issue #73 

### A description of the changes proposed in the pull request and why
Lines 105 and 165, of uibuilderfe.js, threw an error "... 'endsWith' is undefined ..." if length of u (at line 105) or fullPath (line 165) are zero (0) length.

### Environment used for development and testing

Software       | Version
-------------- | -------
Node.JS        | 10.16.3
npm            | 6.11.3
Node-RED       | 1.0.0
uibuilder node | 2.0.4
uibuilderFE    | 
OS             |  linux (Docker - node:lts - as of 03-OCT-2019 MST)
Browser        | Chrome 77.0.3865.90 (Official Build) (64-bit)
Vue                |  2.6.10

