### PR TITLE
cors: support cross-site access to socket.io

### DIFF
--- a/nodes/uibuilder.js
+++ b/nodes/uibuilder.js
@@ -251,7 +251,21 @@ module.exports = function(/** @type Red */ RED) {
     const uib_socketPath = tilib.urlJoin(httpNodeRoot, uib.moduleName, 'vendor', 'socket.io')
 
     log.trace('[uibuilder:Module] Socket.IO initialisation - Socket Path=', uib_socketPath )
-    var io = socketio.listen(RED.server, {'path': uib_socketPath}) // listen === attach
+    let ioOptions = {
+        'path': uib_socketPath,
+        // for CORS need to handle preflight request explicitly 'cause there's an
+        // Allow-Headers:X-ClientId in there.  see https://socket.io/docs/v2/handling-cors/
+        handlePreflightRequest: (req, res) => {
+            res.writeHead(204, {
+              "Access-Control-Allow-Origin": req.headers["origin"],
+              "Access-Control-Allow-Methods": "GET,POST",
+              "Access-Control-Allow-Headers": "X-ClientId",
+              "Access-Control-Allow-Credentials": true,
+            });
+            res.end();
+        },
+    }
+    var io = socketio.listen(RED.server, ioOptions) // listen === attach
     // @ts-ignore
     io.set('transports', ['polling', 'websocket'])
 


### PR DESCRIPTION
### A description of the changes proposed in the pull request and why

This PR enables cross-site access to uibuilder, for example so one can serve the front-end UI code from a standard javascript dev server running on one's laptop, such as using `vue-cli-service serve`. By default socket.io allows cross-site access, however, uibuilder sends an x-clientid custom header which must be explicitly included in the CORS preflight response. IMHO this PR does not reduce security because cross-site access was already allowed, it just didn't work out of the box: an attacker could have simply dropped the x-clientid header to get through.

### Environment used for development and testing

Software       | Version
-------------- | -------
Node.JS        |  v12.22.1
npm            | 
Node-RED       |  v1.3.4
uibuilder node |  v3.2.1
uibuilderFE    |  v3.2.1
OS             |  linux
Browser        |  chrome

