### PR TITLE
Fix error if cookie not matched at all

### DIFF
--- a/nodes/libs/uiblib.js
+++ b/nodes/libs/uiblib.js
@@ -249,7 +249,7 @@ module.exports = {
         let clientId
         if ( req.headers.cookie ) {
             let matches = req.headers.cookie.match(/uibuilder-client-id=(?<id>.{21})/)
-            if ( !matches.groups.id ) clientId = nanoid()
+            if ( !matches || !matches.groups.id ) clientId = nanoid()
             else clientId = matches.groups.id
         } else {
             clientId = nanoid()


### PR DESCRIPTION
### A description of the changes proposed in the pull request and why
Fatal error occurs if any exisiting cookies already exist in the headers (i.e. `req.headers.cookie != null`) but does not match  the regex searching for uibuilder cookie. Since `matches.groups` is then undefined, `matches.group.id` produces an error.