### PR TITLE
Fix glob sync on windows machines

### DIFF
--- a/nodes/libs/fs.cjs
+++ b/nodes/libs/fs.cjs
@@ -44,6 +44,7 @@ const { cp, writeFile, } = require('node:fs') // eslint-disable-line n/no-unsupp
 const { accessSync, cpSync, constants: fsConstants, existsSync, mkdirSync, readFileSync, } = require('node:fs') // eslint-disable-line n/no-unsupported-features/node-builtins
 // TODO Remove in future?
 const fg = require('fast-glob')
+const process = require('node:process')
 // ! We cannot use uibGlobalConfig here because it causes circular requires (its module uses this fs library)
 // The uibuilder global configuration object, used throughout all nodes and libraries.
 // const uibGlobalConfig = require('./uibGlobalConfig.cjs')
@@ -668,6 +669,8 @@ class UibFs {
      */
     fgSync(glob) {
         if (!glob) return []
+        // convert path to pattern before execution on Windows machines; otherwise nothing will be found
+        fg.convertPathToPattern(glob)
         return fg.sync(glob)
     }
 


### PR DESCRIPTION
`fg.sync()` does not work with inputs like `C:\\Users\\user\\.node-red\\uibuilder/test/routes/*.js`; this returns any empty result. This changes converts the glob string to something like `/Users/user/.node-red/uibuilder/test/routes/*.js` for platform `win32` which allows it to find files via glob when running on windows. refer: https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#convertpathtopatternpath

I tested this change using the most recent stable versions of Node-RED and UI-Builder on Windows 11 and Ubuntu 24.04.

We welcome new pull requests to this repository but please follow the [contribution guidelines](https://github.com/TotallyInformation/node-red-contrib-uibuilder/blob/master/.github/CONTRIBUTING.md).

Please ensure that you are happy with the license for this repository and that all of your code meets the requirements for the license.

Please include the following information:

### A reference to any related issues in this repository
n/a

### A description of the changes proposed in the pull request and why
This change adds a conversion of any glob path input to a pattern when running on platform `win32` in order to work and find files correctly.
I found this issue when trying to add custom routes on my windows machine using a exact duplication of my code which was running successfully on Ubuntu. Without this change UI-Builder wasn't able to find any route-files on windows while it was working on Ubuntu.

### Environment used for development and testing

Software       | Version Windows | Version Ubuntu
-------------- | --------------------|------------------
Node.JS        |  v24.3.0                 | v22.17.0
npm              |  11.4.2                  | 11.4.2
Node-RED     |  4.0.9                    | 4.0.9
uibuilder node | uibuilder           | uibuilder
uibuilder client library | n/a       | n/a
OS             |  Windows 11 Pro    | Ubuntu 24.04
Browser        |  MS Edge            | MS Edge